### PR TITLE
fix: registra gRouter (US-02) e corrige imports quebrados em routes/b.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import bulbeRouter from './routes/bulbe.js';
 import produtosRouter from './routes/produtos.js';
+import gRouter from './routes/g.js';
 import hRouter from './routes/h.js';
 import carrinhoRouter from './routes/b.js';
 
@@ -70,6 +71,7 @@ app.get('/api-docs.json', (req, res) => {
 // Rotas de negócio
 app.use('/api/v1/bulbe', bulbeRouter);
 app.use('/api/v1/produtos', produtosRouter);
+app.use('/api/v1/produtos', gRouter);
 app.use('/api/v1/carrinho', hRouter);
 app.use('/api/v1/carrinho', carrinhoRouter);
 

--- a/src/routes/b.js
+++ b/src/routes/b.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
-import { getCarrinho } from '../controllers/bController.js';
-import { autenticarJWT } from '../middleware/auth.js';
+import { getCarrinho } from '../controllers/bControllers.js';
+// TODO: descomentar quando US-23 (infra JWT) for mergeada
+// import { autenticarJWT } from '../middlewares/autenticar.js';
 
 const router = Router();
 
@@ -40,6 +41,7 @@ const router = Router();
  *       500:
  *         description: Erro interno no servidor
  */
-router.get('/', autenticarJWT, getCarrinho);
+// TODO: readicionar autenticarJWT como middleware quando US-23 for mergeada
+router.get('/', getCarrinho);
 
 export default router;


### PR DESCRIPTION
## Resumo

Dois fixes pequenos para destravar a main, que estava quebrada:

1. **Registra `gRouter` em `/api/v1/produtos`** no `app.js` — o PR #40 (US-02) criou `src/routes/g.js` mas esqueceu de registrar no app. Sem isso, `GET /api/v1/produtos/:id` retornava 404.
2. **Corrige typo `bController.js` → `bControllers.js`** em `src/routes/b.js` (linha 2). O nome do arquivo real é com `s`. Sem o fix, o servidor crashava no startup com `ERR_MODULE_NOT_FOUND`.
3. **Comenta `autenticarJWT`** em `src/routes/b.js` (linhas 3 e 43). O middleware ainda não existe — depende da **US-23** (infra JWT). Adicionado TODO indicando para descomentar quando US-23 for mergeada.

## Test plan

- [x] Servidor sobe sem crash (`node src/app.js`)
- [x] `GET /api/v1/produtos/1` → 200 + dados completos
- [x] `GET /api/v1/produtos/999` → 404
- [x] `GET /api/v1/produtos?categoria=lampadas` (US-01, regressão) → 200
- [x] `GET /api/v1/carrinho` ainda retorna 500 — **esperado**, depende da US-23 + ajuste no `bControllers.js` (`req.usuario.id`)

Closes #4