### PR TITLE
fix: corrige US-09 (rota nao registrada), US-06 (middleware) e arquivos j.js (CommonJS->ESM)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ import gRouter from './routes/g.js';
 import hRouter from './routes/h.js';
 import carrinhoRouter from './routes/b.js';
 import eRouter from './routes/e.js';
+import hjRouter from './routes/hj.js';
 
 // Em ESM não existe __dirname — reconstruímos a partir de import.meta.url
 const __filename = fileURLToPath(import.meta.url);
@@ -76,6 +77,7 @@ app.use('/api/v1/produtos', gRouter);
 app.use('/api/v1/carrinho', hRouter);
 app.use('/api/v1/carrinho', carrinhoRouter);
 app.use('/api/v1/carrinho', eRouter);
+app.use('/api/v1/favoritos', hjRouter);
 
 // Health check
 app.get('/', (req, res) => {

--- a/src/controllers/jControllers.js
+++ b/src/controllers/jControllers.js
@@ -1,24 +1,18 @@
-const jData = require('../data/j');
+// src/controllers/jControllers.js
+import { limparCarrinhoNoBanco } from '../data/j.js';
 
-const limparCarrinho = async (req, res) => {
-    try {
-        const usuarioId = req.user?.id || req.body.usuarioId; 
+// Limpar todo o carrinho [US-08]
+export const limparCarrinho = (req, res) => {
+  const usuarioId = req.usuario?.id ?? req.body.usuarioId;
 
-        if (!usuarioId) {
-            return res.status(401).json({ erro: "Usuário não identificado." });
-        }
+  if (!usuarioId) {
+    return res.status(401).json({ erro: 'Usuário não identificado.' });
+  }
 
-        const carrinhoVazio = await jData.limparCarrinhoNoBanco(usuarioId);
+  const carrinhoVazio = limparCarrinhoNoBanco(usuarioId);
 
-        return res.status(200).json({
-            mensagem: "Carrinho esvaziado com sucesso.",
-            carrinho: carrinhoVazio
-        });
-    } catch (error) {
-        return res.status(500).json({ erro: "Erro interno ao limpar o carrinho." });
-    }
-};
-
-module.exports = {
-    limparCarrinho
+  return res.status(200).json({
+    mensagem: 'Carrinho esvaziado com sucesso.',
+    carrinho: carrinhoVazio,
+  });
 };

--- a/src/data/j.js
+++ b/src/data/j.js
@@ -1,11 +1,9 @@
-let carrinhos = {};
+// src/data/j.js
+// Carrinhos por usuário em memória — reiniciados a cada restart.
 
-const limparCarrinhoNoBanco = async (usuarioId) => {
-    carrinhos[usuarioId] = [];
-    
-    return carrinhos[usuarioId];
-};
+const carrinhos = {};
 
-module.exports = {
-    limparCarrinhoNoBanco
+export const limparCarrinhoNoBanco = (usuarioId) => {
+  carrinhos[usuarioId] = [];
+  return carrinhos[usuarioId];
 };

--- a/src/routes/b.js
+++ b/src/routes/b.js
@@ -40,7 +40,6 @@ const router = Router();
  *       500:
  *         description: Erro interno no servidor
  */
-// TODO: readicionar autenticarJWT como middleware quando US-23 for mergeada
-router.get('/', getCarrinho);
+router.get('/', autenticarJWT, getCarrinho);
 
 export default router;

--- a/src/routes/j.js
+++ b/src/routes/j.js
@@ -1,33 +1,36 @@
-const express = require('express');
-const router = express.Router();
-const jControllers = require('../controllers/jControllers');
+// src/routes/j.js
+import { Router } from 'express';
+import { limparCarrinho } from '../controllers/jControllers.js';
+
+const router = Router();
 
 /**
  * @openapi
- * /api/v1/carrinho:
- * delete:
- * summary: Limpar todo o carrinho
- * description: Remove todos os itens do carrinho do usuário autenticado de uma só vez.
- * tags: [Carrinho]
- * security:
- * - jwt: []
- * responses:
- * 200:
- * description: Carrinho limpo com sucesso.
- * content:
- * application/json:
- * schema:
- * type: object
- * properties:
- * mensagem:
- * type: string
- * carrinho:
- * type: array
- * items: {}
- * example: []
- * 401:
- * description: Não autorizado (Token JWT ausente ou inválido).
+ * /carrinho:
+ *   delete:
+ *     summary: Limpar todo o carrinho
+ *     description: Remove todos os itens do carrinho do usuário autenticado de uma só vez.
+ *     tags:
+ *       - Carrinho
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Carrinho limpo com sucesso.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 mensagem:
+ *                   type: string
+ *                 carrinho:
+ *                   type: array
+ *                   items: {}
+ *                   example: []
+ *       401:
+ *         description: Não autorizado (token JWT ausente ou inválido).
  */
-router.delete('/carrinho', jControllers.limparCarrinho);
+router.delete('/', limparCarrinho);
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
## Resumo

Corrige 3 problemas encontrados na revisão geral da main:

1. **US-09 retornava 404** — `routes/hj.js` foi mergeado mas nunca registrado em `app.js`. Agora `GET /api/v1/favoritos` funciona.
2. **US-06 retornava 500** — `autenticarJWT` foi removido temporariamente quando o middleware ainda não existia. Agora foi reaplicado.
3. **Arquivos `j.js` usavam CommonJS** (`require`/`module.exports`) num projeto ESM (`"type": "module"`). Convertidos para `import`/`export`. JSDoc OpenAPI quebrado também foi corrigido (eliminou warnings YAMLSemanticError no startup).

## Commits (5 — granulares e revertíveis individualmente)

| # | Hash | Tipo | Descrição |
|---|---|---|---|
| 1 | `bdfd723` | fix | Registra hjRouter em /favoritos (US-09) |
| 2 | `ac8d52d` | fix | Reaplica autenticarJWT em GET /carrinho (US-06) |
| 3 | `1943520` | refactor | data/j.js → ESM |
| 4 | `d63d45c` | refactor | controllers/jControllers.js → ESM |
| 5 | `7ec82a2` | refactor | routes/j.js → ESM + JSDoc |

## Test plan

| Teste | Esperado | Resultado |
|---|---|---|
| GET /api/v1/favoritos COM token | 200 + lista | ✅ |
| GET /api/v1/favoritos SEM token | 401 | ✅ |
| GET /api/v1/carrinho COM token | 200 + itens | ✅ |
| GET /api/v1/carrinho SEM token | 401 | ✅ |
| GET /api/v1/produtos?categoria=lampadas (regressão US-01) | 200 | ✅ |
| GET /api/v1/produtos/1 (regressão US-02) | 200 | ✅ |
| POST /api/v1/carrinho/itens (regressão US-04) | 201 | ✅ |
| DELETE /api/v1/carrinho/itens/1 COM token (regressão US-07) | 200 | ✅ |
| Servidor sobe sem warnings YAMLSemanticError | sem warnings | ✅ |

Closes #11