### PR TITLE
fix: renomeia campo cvv para cod_seguranca em processarPagamento (US-15)

### DIFF
--- a/src/controllers/bulbeControllers.js
+++ b/src/controllers/bulbeControllers.js
@@ -37,7 +37,7 @@ export const selecionarEntrega = (req, res) => {
 //Processar pagamento do pedido[US-15]
 export const processarPagamento = (req,res) => {
 
-    const {metodo,nome_titular,num_cartao,validade,cvv} = req.body;
+    const {metodo,nome_titular,num_cartao,validade,cod_seguranca} = req.body;
     const idPedido = parseInt(req.params.id,10);
 
     if(isNaN(idPedido)){
@@ -55,7 +55,7 @@ export const processarPagamento = (req,res) => {
     }
 
     if(formaPagamento.precisaCartao === true){
-        if(!nome_titular || !num_cartao || !validade || !cvv){
+        if(!nome_titular || !num_cartao || !validade || !cod_seguranca){
             return res.status(422).json({
                 erro:"Dados do cartão obrigatórios faltando"
             });


### PR DESCRIPTION
## Resumo

A DoD da US-15 e a documentação OpenAPI (em `routes/bulbe.js`) já declaravam o campo do código de segurança do cartão como **`cod_seguranca`**, mas o controller `processarPagamento` em `bulbeControllers.js` estava destruturando o body usando `cvv`.

**Efeito do bug:** pagamentos com cartão (crédito/débito) retornavam **422 "Dados do cartão obrigatórios faltando"** mesmo quando o cliente enviava todos os campos corretos usando o nome documentado (`cod_seguranca`).

## Mudanças

- `src/controllers/bulbeControllers.js`: `cvv` → `cod_seguranca` nas 2 ocorrências (destructuring e validação)
- Nenhuma outra alteração — JSDoc, schema OpenAPI e endpoint permanecem iguais

## Test plan

| Teste | Antes | Depois |
|---|---|---|
| POST cartão com `cvv` (campo errado) | 422 (passava porque destructuring batia) | 422 (esperado — campo não documentado) |
| POST cartão com `cod_seguranca` (correto) | **422 (bug)** | **200 ✅** |
| POST PIX | 200 | 200 |
| POST cartão sem nenhum campo | 422 | 422 |
| GET rastreamento (US-20) | 200 | 200 |
| Regressão US-01 (GET produtos) | 200 | 200 |

## Pendências fora do escopo (resolver depois)

Os endpoints de pedidos hoje ficam em `/api/v1/bulbe/pedidos/*`, divergindo da DoD que pede `/api/v1/pedidos/*`. Conforme combinado, consolidação fica para a migração para o banco de dados (Sprint 3).

JWT também faltando — depende da US-23.