### PR TITLE
feat: US-16 confirmar e registrar pedido

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,7 @@ import produtosRouter from './routes/produtos.js';
 import gRouter, { gCarrinhoRouter } from './routes/g.js';
 import hRouter, { hPedidosRouter } from './routes/h.js';
 import carrinhoRouter from './routes/b.js';
-import eRouter from './routes/e.js';
+import eRouter, { ePedidosRouter } from './routes/e.js';
 import hjRouter from './routes/hj.js';
 import jRouter, { jPublicRouter } from './routes/j.js';
 import authRouter from './routes/auth.js';
@@ -95,6 +95,7 @@ app.use('/api/v1/carrinho', autenticarJWT, eRouter);
 app.use('/api/v1/carrinho', autenticarJWT, gCarrinhoRouter);
 app.use('/api/v1/favoritos', autenticarJWT, hjRouter);
 app.use('/api/v1/pedidos', autenticarJWT, hPedidosRouter);
+app.use('/api/v1/pedidos', autenticarJWT, ePedidosRouter);
 
 // Rotas públicas (sem JWT) — montadas em /api/v1
 app.use('/api/v1', jPublicRouter);

--- a/src/controllers/eControllers.js
+++ b/src/controllers/eControllers.js
@@ -1,5 +1,6 @@
 // src/controllers/eControllers.js
 import { carrinho } from '../data/e.js';
+import { carrinho as carrinhoPrincipal, pedidos } from '../data/h.js';
 import { produtos } from '../data/produtos.js';
 
 // Adicionar produto ao carrinho [US-04]
@@ -34,4 +35,55 @@ export const adicionarItemCarrinho = (req, res) => {
   const novoItem = { produtoId, quantidade };
   carrinho.push(novoItem);
   return res.status(201).json(novoItem);
+};
+
+// Confirmar e registrar pedido [US-16]
+export const confirmarPedido = (req, res) => {
+  const { enderecoEntrega, formaEntrega, metodoPagamento } = req.body;
+
+  if (!enderecoEntrega || !formaEntrega || !metodoPagamento) {
+    return res.status(422).json({
+      erro: 'Os campos "enderecoEntrega", "formaEntrega" e "metodoPagamento" são obrigatórios.',
+    });
+  }
+
+  if (carrinhoPrincipal.length === 0) {
+    return res.status(400).json({
+      erro: 'Carrinho vazio. Adicione itens antes de confirmar o pedido.',
+    });
+  }
+
+  const itens = carrinhoPrincipal.map((item) => ({
+    produtoId: item.produtoId,
+    nome: item.nome,
+    precoUnitario: item.preco,
+    quantidade: item.quantidade,
+  }));
+
+  const valorTotal = itens.reduce(
+    (total, item) => total + item.precoUnitario * item.quantidade,
+    0,
+  );
+
+  const proximoId = pedidos.length === 0
+    ? 1
+    : Math.max(...pedidos.map((p) => p.pedidoId)) + 1;
+
+  const novoPedido = {
+    pedidoId: proximoId,
+    usuarioId: req.usuario.id,
+    itens,
+    enderecoEntrega,
+    formaEntrega,
+    metodoPagamento,
+    valorTotal: Number(valorTotal.toFixed(2)),
+    status: 'confirmado',
+    dataCriacao: new Date().toISOString(),
+  };
+
+  pedidos.push(novoPedido);
+  carrinhoPrincipal.length = 0;
+
+  const { usuarioId, ...resposta } = novoPedido;
+  return res.status(201).json(resposta);
 };

--- a/src/routes/e.js
+++ b/src/routes/e.js
@@ -62,10 +62,85 @@
  *               $ref: '#/components/schemas/Erro'
  */
 import { Router } from 'express';
-import { adicionarItemCarrinho } from '../controllers/eControllers.js';
+import { adicionarItemCarrinho, confirmarPedido } from '../controllers/eControllers.js';
 
 const router = Router();
 
 router.post('/itens', adicionarItemCarrinho);
 
 export default router;
+
+// Router de pedidos [US-16]
+export const ePedidosRouter = Router();
+
+/**
+ * @openapi
+ * /pedidos:
+ *   post:
+ *     summary: Confirma e registra um novo pedido [US-16]
+ *     description: |
+ *       Cria um pedido a partir do carrinho atual. Esvazia o carrinho após confirmação.
+ *       Observação: usa o carrinho gerenciado por routes/h.js (POST /carrinho/itens, etc).
+ *     tags:
+ *       - Pedidos
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - enderecoEntrega
+ *               - formaEntrega
+ *               - metodoPagamento
+ *             properties:
+ *               enderecoEntrega:
+ *                 type: object
+ *                 properties:
+ *                   logradouro:  { type: string, example: Avenida Paulista }
+ *                   numero:      { type: string, example: "1000" }
+ *                   complemento: { type: string, example: "Apto 42" }
+ *                   bairro:      { type: string, example: Bela Vista }
+ *                   localidade:  { type: string, example: São Paulo }
+ *                   uf:          { type: string, example: SP }
+ *                   cep:         { type: string, example: "01310100" }
+ *               formaEntrega:
+ *                 type: string
+ *                 example: PAC
+ *               metodoPagamento:
+ *                 type: string
+ *                 example: cartao_credito
+ *     responses:
+ *       201:
+ *         description: Pedido criado com sucesso. Carrinho esvaziado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 pedidoId:        { type: integer, example: 3 }
+ *                 itens:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       produtoId:     { type: integer }
+ *                       nome:          { type: string }
+ *                       precoUnitario: { type: number }
+ *                       quantidade:    { type: integer }
+ *                 enderecoEntrega: { type: object }
+ *                 formaEntrega:    { type: string, example: PAC }
+ *                 metodoPagamento: { type: string, example: cartao_credito }
+ *                 valorTotal:      { type: number, example: 259.70 }
+ *                 status:          { type: string, example: confirmado }
+ *                 dataCriacao:     { type: string, format: date-time }
+ *       400:
+ *         description: Carrinho vazio.
+ *       401:
+ *         description: Token JWT ausente ou inválido.
+ *       422:
+ *         description: Campos obrigatórios ausentes no body.
+ */
+ePedidosRouter.post('/', confirmarPedido);


### PR DESCRIPTION
## Resumo

Implementa POST /api/v1/pedidos (US-16, issue #18): cria um pedido a partir do carrinho atual, esvazia o carrinho, retorna 201 com os dados do pedido. Integra com a US-17 (GET /pedidos/:id) reusando os arrays \`pedidos\` e \`carrinho\` exportados de \`data/h.js\`.

## DoD coberta (issue #18)

- [x] 201 com dados do pedido criado
- [x] Inclui pedidoId, itens, enderecoEntrega, formaEntrega, metodoPagamento, valorTotal, status (e dataCriacao como bonus)
- [x] Carrinho esvaziado após confirmação
- [x] 400 se carrinho vazio
- [x] Exige JWT (mount-level em app.js)
- [x] Endpoint documentado com \`@openapi\` e visível em /api-docs

## Commits granulares (Conventional Commits)

- 86a10db — controller \`confirmarPedido\` com validações
- cc5447b — \`ePedidosRouter\` com bloco \`@openapi\`
- 03e229d — registro do router em app.js

## Testes manuais (todos passaram)

| # | Cenário | Esperado | Resultado |
|---|---|---|---|
| 1 | POST /pedidos sem token | 401 | 401 ✓ |
| 2 | POST /pedidos com token mas body vazio | 422 | 422 ✓ |
| 3 | POST /pedidos com carrinho cheio + body válido | 201 + pedido | 201, pedidoId=3, valorTotal=708.70 ✓ |
| 4 | POST /pedidos imediatamente depois (carrinho vazio) | 400 | 400 ✓ |
| 5 | GET /pedidos/3 (criado no teste 3) | 200 | 200 ✓ — integra com US-17 |

## Observações

- Uso o \`carrinho\` exportado de \`data/h.js\` (não \`data/e.js\`) porque ele tem o schema completo com \`nome\` e \`preco\`, necessário pra montar \`itens\` do pedido.
- O \`@openapi\` segue o estilo já adotado no projeto (mesmo nível da US-17). Itens mais refinados do guia da Aula 09 (operationId, schemas em components, \$ref, examples nomeados) ficam pra eventual passada de refinamento — não afetam comportamento da API.

Closes #18