### PR TITLE
fix: corrige filtro destaque (US-03) e implementa JWT real no middleware

### DIFF
--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -1,0 +1,6 @@
+// src/config/auth.js
+// Configuracao centralizada de autenticacao JWT.
+// Usado pelo authController (assinatura) e pelo middleware autenticarJWT (verificacao).
+
+export const JWT_SECRET = 'bulbe-segredo-jwt';
+export const JWT_EXPIRES_IN = '24h';

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,9 +1,7 @@
 // src/controllers/authController.js
 import jwt from 'jsonwebtoken';
 import { usuarios } from '../data/usuarios.js';
-
-const SEGREDO = 'bulbe-segredo-jwt';
-const EXPIRES_IN = '24h';
+import { JWT_SECRET, JWT_EXPIRES_IN } from '../config/auth.js';
 
 // POST /auth/login [US-18]
 export function login(req, res) {
@@ -20,8 +18,8 @@ export function login(req, res) {
 
   const token = jwt.sign(
     { id: usuario.id, email: usuario.email },
-    SEGREDO,
-    { expiresIn: EXPIRES_IN },
+    JWT_SECRET,
+    { expiresIn: JWT_EXPIRES_IN },
   );
 
   return res.status(200).json({

--- a/src/controllers/produtosController.js
+++ b/src/controllers/produtosController.js
@@ -1,44 +1,32 @@
 // src/controllers/produtosController.js
 import { produtos, CATEGORIAS_VALIDAS } from '../data/produtos.js';
 
-// Listar produtos por categoria [US-01]
+// Listar produtos com filtros opcionais [US-01 + RF-03]
+// Queries suportadas: ?categoria, ?destaque=true, ?maisVendido=true
 export const listarProdutos = (req, res) => {
-  const { categoria } = req.query;
+  const { categoria, destaque, maisVendido } = req.query;
 
-  if (!categoria) {
-    return res.status(200).json(produtos);
-  }
-
-  if (!CATEGORIAS_VALIDAS.includes(categoria)) {
+  if (categoria && !CATEGORIAS_VALIDAS.includes(categoria)) {
     return res.status(404).json({
       erro: `Categoria "${categoria}" não encontrada. Categorias válidas: ${CATEGORIAS_VALIDAS.join(', ')}.`,
     });
   }
 
-  const filtrados = produtos.filter((produto) => produto.categoria === categoria);
-  return res.status(200).json(filtrados);
-};
+  let resultado = [...produtos];
 
-// Listar produtos em destaque ou mais vendidos [RF-03]
-export function getProdutosDestaque(req, res) {
-  try {
-    const { destaque, maisVendido } = req.query;
-
-    let resultado = [...produtos];
-
-    if (destaque === 'true') {
-      resultado = resultado.filter(p => p.destaque === true);
-    }
-
-    if (maisVendido === 'true') {
-      resultado = resultado.filter(p => p.maisVendido === true);
-    }
-
-    resultado.sort((a, b) => b.avaliacao - a.avaliacao);
-
-    return res.status(200).json(resultado);
-
-  } catch (error) {
-    return res.status(500).json({ mensagem: 'Erro ao buscar produtos.' });
+  if (categoria) {
+    resultado = resultado.filter((p) => p.categoria === categoria);
   }
-}
+  if (destaque === 'true') {
+    resultado = resultado.filter((p) => p.destaque === true);
+  }
+  if (maisVendido === 'true') {
+    resultado = resultado.filter((p) => p.maisVendido === true);
+  }
+
+  if (destaque === 'true' || maisVendido === 'true') {
+    resultado.sort((a, b) => b.avaliacao - a.avaliacao);
+  }
+
+  return res.status(200).json(resultado);
+};

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,10 +1,23 @@
 // src/middleware/auth.js
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../config/auth.js';
+
 export const autenticarJWT = (req, res, next) => {
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ erro: 'Token JWT ausente ou inválido.' });
   }
-  // Popula req.usuario com dados mock até integração real de JWT
-  req.usuario = { id: 1 };
-  next();
+
+  const token = authHeader.slice('Bearer '.length).trim();
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.usuario = { id: decoded.id, email: decoded.email };
+    return next();
+  } catch (err) {
+    const mensagem = err.name === 'TokenExpiredError'
+      ? 'Token JWT expirado.'
+      : 'Token JWT inválido.';
+    return res.status(401).json({ erro: mensagem });
+  }
 };

--- a/src/routes/produtos.js
+++ b/src/routes/produtos.js
@@ -63,7 +63,7 @@
  *           example: Categoria "invalida" não encontrada.
  */
 import { Router } from 'express';
-import { listarProdutos, getProdutosDestaque } from '../controllers/produtosController.js';
+import { listarProdutos } from '../controllers/produtosController.js';
 
 const router = Router();
 
@@ -71,8 +71,13 @@ const router = Router();
  * @openapi
  * /produtos:
  *   get:
- *     summary: Lista produtos filtrados por categoria
- *     description: Retorna a lista de produtos do catálogo. Pode ser filtrada por categoria via query string.
+ *     summary: Lista produtos com filtros opcionais
+ *     description: |
+ *       Retorna a lista de produtos do catálogo. Aceita filtros combináveis via query string:
+ *       - `categoria` (US-01): filtra por categoria
+ *       - `destaque=true` (RF-03): só produtos em destaque
+ *       - `maisVendido=true` (RF-03): só mais vendidos
+ *       Quando `destaque` ou `maisVendido` é aplicado, resultado é ordenado por avaliação (desc).
  *     tags:
  *       - Produtos
  *     parameters:
@@ -82,8 +87,20 @@ const router = Router();
  *         schema:
  *           type: string
  *           enum: [lampadas, luminarias, fitas, acessorios, assistentes]
- *         description: Categoria para filtrar os produtos. Se omitida, retorna todos.
+ *         description: Categoria para filtrar os produtos.
  *         example: lampadas
+ *       - in: query
+ *         name: destaque
+ *         required: false
+ *         schema:
+ *           type: boolean
+ *         description: Se true, retorna apenas produtos em destaque.
+ *       - in: query
+ *         name: maisVendido
+ *         required: false
+ *         schema:
+ *           type: boolean
+ *         description: Se true, retorna apenas produtos mais vendidos.
  *     responses:
  *       200:
  *         description: Lista de produtos retornada com sucesso (pode ser vazia).
@@ -102,36 +119,4 @@ const router = Router();
  */
 router.get('/', listarProdutos);
 
-/**
- * @openapi
- * /produtos/destaque:
- *   get:
- *     summary: Lista produtos em destaque ou mais vendidos
- *     description: Retorna produtos filtrados por destaque ou maisVendido, ordenados por avaliação.
- *     tags:
- *       - Produtos
- *     parameters:
- *       - in: query
- *         name: destaque
- *         schema:
- *           type: boolean
- *         description: Filtra produtos em destaque
- *       - in: query
- *         name: maisVendido
- *         schema:
- *           type: boolean
- *         description: Filtra produtos mais vendidos
- *     responses:
- *       200:
- *         description: Lista de produtos filtrada e ordenada
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Produto'
- *       500:
- *         description: Erro interno no servidor
- */
-router.get('/destaque', getProdutosDestaque);
 export default router;


### PR DESCRIPTION
## Resumo

Dois fixes pequenos e independentes que desbloqueiam funcionalidades hoje quebradas:

1. **Filtro \`?destaque=true\` na rota GET /produtos** — antes era ignorado pela rota raiz; o filtro só funcionava em \`/produtos/destaque\` (URL diferente da DoD).
2. **Middleware autenticarJWT decodifica token real** — antes era mock que forçava \`req.usuario.id=1\` independente do usuário logado.

---

## Fix 1 — US-03 filtro destaque

### DoD
- [x] \`GET /api/v1/produtos?destaque=true\` retorna só produtos em destaque (3 produtos: ids 1, 3, 9)
- [x] \`GET /api/v1/produtos?maisVendido=true\` retorna só mais vendidos (4 produtos: ids 1, 5, 9, 10)
- [x] Filtros combinaveis: \`?destaque=true&maisVendido=true\` retorna interseção (ids 1, 9)
- [x] \`?categoria=lampadas\` continua funcionando
- [x] \`?categoria=invalida\` retorna 404
- [x] Rota /produtos/destaque removida
- [x] JSDoc atualizado

### Mudanças
- \`src/controllers/produtosController.js\` — combinada \`getProdutosDestaque\` dentro de \`listarProdutos\`
- \`src/routes/produtos.js\` — removida rota /destaque e seu JSDoc; JSDoc da rota raiz atualizado

---

## Fix 2 — Middleware JWT real

### DoD
- [x] \`autenticarJWT\` chama \`jwt.verify(token, JWT_SECRET)\` em vez de mock
- [x] \`req.usuario\` contém \`{id, email}\` decodificados do token
- [x] Token inválido retorna 401 com mensagem \"Token JWT inválido\"
- [x] Token expirado retorna 401 com mensagem \"Token JWT expirado\"
- [x] Segredo extraido para \`src/config/auth.js\` (alinha com guia da Aula 10)
- [x] Bernardo (id=1) vê só pedidos com usuarioId=1; Emanuel (id=2) vê só com usuarioId=2

### Mudanças
- \`src/config/auth.js\` (novo) — exporta \`JWT_SECRET\` e \`JWT_EXPIRES_IN\`
- \`src/controllers/authController.js\` — importa do config em vez de constantes locais
- \`src/middleware/auth.js\` — implementa \`jwt.verify\` real com tratamento de erro

---

## Testes manuais (todos passaram)

### Filtro destaque
| # | Request | Esperado | Resultado |
|---|---|---|---|
| T1 | GET /produtos?destaque=true | 3 produtos | ids [9, 3, 1] (ordenados por avaliacao) ✓ |
| T2 | GET /produtos?maisVendido=true | 4 produtos | ids [9, 1, 10, 5] ✓ |
| T3 | GET /produtos?destaque=true&maisVendido=true | 2 produtos | ids [9, 1] ✓ |
| T4 | GET /produtos | 10 produtos | 10 ✓ |
| T5 | GET /produtos?categoria=invalida | 404 | 404 + mensagem ✓ |
| T7 | GET /produtos?categoria=lampadas | 2 produtos | 2 todos da categoria lampadas ✓ |

### Middleware JWT
| # | Request | Esperado | Resultado |
|---|---|---|---|
| T8 | GET /carrinho com token valido | 200 | 200 ✓ |
| T9 | GET /carrinho com token fake | 401 \"Token invalido\" | 401 ✓ |
| T10 | GET /pedidos/2 com token Emanuel (id=2) | 200 | 200 ✓ — pedido pertence ao usuario |
| T11 | GET /pedidos/1 com token Emanuel (id=2) | 403 | 403 \"Acesso negado\" ✓ |

---

## Commits

- \`d1622b9\` — fix: GET /produtos passa a aplicar filtros destaque e maisVendido na rota raiz (US-03)
- \`6e379c1\` — refactor: extrai segredo JWT para src/config/auth.js
- \`3a58f38\` — fix: middleware autenticarJWT decodifica token JWT real em vez de mock

---

## Impacto colateral conhecido

Com o middleware JWT real, comportamentos antes \"mascarados\" pelo mock vão aparecer:
- Emanuel (id=2) agora vê 403 ao tentar buscar pedidos do Bernardo (id=1). Isso e o comportamento CORRETO — antes o mock forcava id=1 entao qualquer usuario via tudo.
- \`bControllers.getCarrinho\` (dead code) filtra por usuarioId. Se for revivido como source of truth, Emanuel verá carrinho vazio porque o hardcoded em data/b.js só tem itens com usuarioId=1.

Isso e desejado — expõe o estado real dos dados, que será resolvido pela migração SQLite (US-36 a US-42).