### PR TITLE
feat(db): migra eControllers (carrinho + pedidos) para SQLite [#71]

### DIFF
--- a/src/controllers/eControllers.js
+++ b/src/controllers/eControllers.js
@@ -1,7 +1,5 @@
 // src/controllers/eControllers.js
-import { carrinho } from '../data/e.js';
-import { carrinho as carrinhoPrincipal, pedidos } from '../data/h.js';
-import { produtos } from '../data/produtos.js';
+import db from '../db/conexao.js';
 
 // Adicionar produto ao carrinho [US-04]
 export const adicionarItemCarrinho = (req, res) => {
@@ -19,22 +17,29 @@ export const adicionarItemCarrinho = (req, res) => {
     });
   }
 
-  const produto = produtos.find((p) => p.id === produtoId);
+  const produto = db.prepare('SELECT id FROM produtos WHERE id = ?').get(produtoId);
   if (!produto) {
     return res.status(404).json({
       erro: `Produto com id ${produtoId} não encontrado.`,
     });
   }
 
-  const itemExistente = carrinho.find((i) => i.produtoId === produtoId);
+  const usuarioId = req.usuario.id;
+  const itemExistente = db
+    .prepare('SELECT id, quantidade FROM carrinho WHERE usuario_id = ? AND produto_id = ?')
+    .get(usuarioId, produtoId);
+
   if (itemExistente) {
-    itemExistente.quantidade += quantidade;
-    return res.status(200).json(itemExistente);
+    const novaQuantidade = itemExistente.quantidade + quantidade;
+    db.prepare('UPDATE carrinho SET quantidade = ? WHERE id = ?')
+      .run(novaQuantidade, itemExistente.id);
+    return res.status(200).json({ produtoId, quantidade: novaQuantidade });
   }
 
-  const novoItem = { produtoId, quantidade };
-  carrinho.push(novoItem);
-  return res.status(201).json(novoItem);
+  db.prepare(
+    'INSERT INTO carrinho (usuario_id, produto_id, quantidade) VALUES (?, ?, ?)',
+  ).run(usuarioId, produtoId, quantidade);
+  return res.status(201).json({ produtoId, quantidade });
 };
 
 // Confirmar e registrar pedido [US-16]
@@ -47,43 +52,71 @@ export const confirmarPedido = (req, res) => {
     });
   }
 
-  if (carrinhoPrincipal.length === 0) {
+  const usuarioId = req.usuario.id;
+
+  // Itens do carrinho do usuário, com nome e preço vindos da tabela produtos.
+  const itens = db
+    .prepare(`
+      SELECT c.produto_id AS produtoId,
+             p.nome        AS nome,
+             p.preco       AS precoUnitario,
+             c.quantidade  AS quantidade
+      FROM carrinho c
+      JOIN produtos p ON p.id = c.produto_id
+      WHERE c.usuario_id = ?
+    `)
+    .all(usuarioId);
+
+  if (itens.length === 0) {
     return res.status(400).json({
       erro: 'Carrinho vazio. Adicione itens antes de confirmar o pedido.',
     });
   }
 
-  const itens = carrinhoPrincipal.map((item) => ({
-    produtoId: item.produtoId,
-    nome: item.nome,
-    precoUnitario: item.preco,
-    quantidade: item.quantidade,
-  }));
-
-  const valorTotal = itens.reduce(
-    (total, item) => total + item.precoUnitario * item.quantidade,
-    0,
+  const valorTotal = Number(
+    itens
+      .reduce((total, item) => total + item.precoUnitario * item.quantidade, 0)
+      .toFixed(2),
   );
 
-  const proximoId = pedidos.length === 0
-    ? 1
-    : Math.max(...pedidos.map((p) => p.pedidoId)) + 1;
+  const dataCriacao = new Date().toISOString();
 
-  const novoPedido = {
-    pedidoId: proximoId,
-    usuarioId: req.usuario.id,
+  // Transação: cria o pedido, seus itens e esvazia o carrinho de forma atômica.
+  const registrarPedido = db.transaction(() => {
+    const info = db
+      .prepare(`
+        INSERT INTO pedidos
+          (usuario_id, valor_total, status, forma_entrega, metodo_pagamento, data_criacao)
+        VALUES
+          (@usuarioId, @valorTotal, 'confirmado', @formaEntrega, @metodoPagamento, @dataCriacao)
+      `)
+      .run({ usuarioId, valorTotal, formaEntrega, metodoPagamento, dataCriacao });
+
+    const pedidoId = info.lastInsertRowid;
+
+    const inserirItem = db.prepare(`
+      INSERT INTO pedido_itens (pedido_id, produto_id, nome, quantidade, preco_unitario)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    for (const item of itens) {
+      inserirItem.run(pedidoId, item.produtoId, item.nome, item.quantidade, item.precoUnitario);
+    }
+
+    db.prepare('DELETE FROM carrinho WHERE usuario_id = ?').run(usuarioId);
+
+    return pedidoId;
+  });
+
+  const pedidoId = registrarPedido();
+
+  return res.status(201).json({
+    pedidoId,
     itens,
     enderecoEntrega,
     formaEntrega,
     metodoPagamento,
-    valorTotal: Number(valorTotal.toFixed(2)),
+    valorTotal,
     status: 'confirmado',
-    dataCriacao: new Date().toISOString(),
-  };
-
-  pedidos.push(novoPedido);
-  carrinhoPrincipal.length = 0;
-
-  const { usuarioId, ...resposta } = novoPedido;
-  return res.status(201).json(resposta);
+    dataCriacao,
+  });
 };


### PR DESCRIPTION
## Issue
Closes #71 - [SQLite] Migrar eControllers (carrinho + pedidos) para SQLite

> ⚠️ **PR empilhado (stacked).** Base = `feat/sqlite-conexao-db` (PR #83, issue #66), nao a `main`. O diff mostra so o controller. **Mergear o #83 primeiro**; depois o GitHub re-aponta este PR para a `main` automaticamente.

## O que foi feito
Migra as duas funcoes do `eControllers.js` de arrays em memoria para SQL via `better-sqlite3`, usando a conexao unica de `src/db/conexao.js`.

- `import db from '../db/conexao.js'` (saem os imports de data/e.js, data/h.js, data/produtos.js)
- **adicionarItemCarrinho (US-04):** SELECT/INSERT/UPDATE na tabela `carrinho`, escopado por `usuario_id`
- **confirmarPedido (US-16):** SELECT do carrinho com JOIN em `produtos` (nome + preco), INSERT em `pedidos` + `pedido_itens` e limpeza do `carrinho` dentro de uma **transacao** (atomicidade ACID)
- Parametros nomeados/posicionais em todas as queries - nunca concatenacao de string (anti SQL injection)

## DoD - criterios de aceitacao
- [x] Trocar `import {...} from '../data/...'` por `import db from '../db/conexao.js'`
- [x] Reescrever cada funcao com `db.prepare(...)` (.all / .get / .run)
- [x] Parametros nomeados/posicionais (anti SQL injection)
- [x] Manter o mesmo contrato HTTP (status codes e formato JSON identicos)
- [x] Manter a documentacao `@openapi` das rotas (nao alterei `routes/e.js`)

## Aviso importante - US-04 e codigo morto (roteamento)
`POST /carrinho/itens` esta montado em DOIS routers no `app.js`: `hRouter` (linha 92) e `eRouter` (linha 94). O Express executa o primeiro que casa -> a versao do `h.js` ganha e **a funcao `adicionarItemCarrinho` deste controller nunca e alcancada via HTTP.**

Migrei mesmo assim porque a DoD lista esse endpoint e para o controller ficar 100% em SQL (sem metade em array). A funcao esta correta e validada - so nao e chamada enquanto a colisao de rotas existir. **Resolver a ordem de montagem e outro escopo** (mexe em `app.js` / `h.js`); sugiro issue propria se o grupo quiser ativar esta versao.

## Como validei (req/res mockados + seed descartavel)
- US-04: 201 novo item | 200 incrementa qtd | 201 2o produto | 422 campo faltando | 422 qtd invalida | 404 produto inexistente
- US-16: 422 campos faltando | 201 confirma (valorTotal correto, itens com nome+preco via JOIN, carrinho esvaziado, `pedidos`+`pedido_itens` gravados) | 400 carrinho vazio
- Transacao e FKs respeitadas; `bulbe.db` de teste nao versionado

## Fora de escopo
- Persistir endereco de entrega -> tabela `enderecos` pertence a outra issue; aqui o endereco e so ecoado na resposta (mesmo comportamento de antes)
- seed.js (#67) e .gitignore/README (#68)