### PR TITLE
feat(db): migra eControllers (carrinho + pedidos) para SQLite [#71]

### DIFF
--- a/src/controllers/eControllers.js
+++ b/src/controllers/eControllers.js
@@ -1,7 +1,5 @@
 // src/controllers/eControllers.js
-import { carrinho } from '../data/e.js';
-import { carrinho as carrinhoPrincipal, pedidos } from '../data/h.js';
-import { produtos } from '../data/produtos.js';
+import db from '../db/conexao.js';
 
 // Adicionar produto ao carrinho [US-04]
 export const adicionarItemCarrinho = (req, res) => {
@@ -19,22 +17,29 @@ export const adicionarItemCarrinho = (req, res) => {
     });
   }
 
-  const produto = produtos.find((p) => p.id === produtoId);
+  const produto = db.prepare('SELECT id FROM produtos WHERE id = ?').get(produtoId);
   if (!produto) {
     return res.status(404).json({
       erro: `Produto com id ${produtoId} não encontrado.`,
     });
   }
 
-  const itemExistente = carrinho.find((i) => i.produtoId === produtoId);
+  const usuarioId = req.usuario.id;
+  const itemExistente = db
+    .prepare('SELECT id, quantidade FROM carrinho WHERE usuario_id = ? AND produto_id = ?')
+    .get(usuarioId, produtoId);
+
   if (itemExistente) {
-    itemExistente.quantidade += quantidade;
-    return res.status(200).json(itemExistente);
+    const novaQuantidade = itemExistente.quantidade + quantidade;
+    db.prepare('UPDATE carrinho SET quantidade = ? WHERE id = ?')
+      .run(novaQuantidade, itemExistente.id);
+    return res.status(200).json({ produtoId, quantidade: novaQuantidade });
   }
 
-  const novoItem = { produtoId, quantidade };
-  carrinho.push(novoItem);
-  return res.status(201).json(novoItem);
+  db.prepare(
+    'INSERT INTO carrinho (usuario_id, produto_id, quantidade) VALUES (?, ?, ?)',
+  ).run(usuarioId, produtoId, quantidade);
+  return res.status(201).json({ produtoId, quantidade });
 };
 
 // Confirmar e registrar pedido [US-16]
@@ -47,43 +52,71 @@ export const confirmarPedido = (req, res) => {
     });
   }
 
-  if (carrinhoPrincipal.length === 0) {
+  const usuarioId = req.usuario.id;
+
+  // Itens do carrinho do usuário, com nome e preço vindos da tabela produtos.
+  const itens = db
+    .prepare(`
+      SELECT c.produto_id AS produtoId,
+             p.nome        AS nome,
+             p.preco       AS precoUnitario,
+             c.quantidade  AS quantidade
+      FROM carrinho c
+      JOIN produtos p ON p.id = c.produto_id
+      WHERE c.usuario_id = ?
+    `)
+    .all(usuarioId);
+
+  if (itens.length === 0) {
     return res.status(400).json({
       erro: 'Carrinho vazio. Adicione itens antes de confirmar o pedido.',
     });
   }
 
-  const itens = carrinhoPrincipal.map((item) => ({
-    produtoId: item.produtoId,
-    nome: item.nome,
-    precoUnitario: item.preco,
-    quantidade: item.quantidade,
-  }));
-
-  const valorTotal = itens.reduce(
-    (total, item) => total + item.precoUnitario * item.quantidade,
-    0,
+  const valorTotal = Number(
+    itens
+      .reduce((total, item) => total + item.precoUnitario * item.quantidade, 0)
+      .toFixed(2),
   );
 
-  const proximoId = pedidos.length === 0
-    ? 1
-    : Math.max(...pedidos.map((p) => p.pedidoId)) + 1;
+  const dataCriacao = new Date().toISOString();
 
-  const novoPedido = {
-    pedidoId: proximoId,
-    usuarioId: req.usuario.id,
+  // Transação: cria o pedido, seus itens e esvazia o carrinho de forma atômica.
+  const registrarPedido = db.transaction(() => {
+    const info = db
+      .prepare(`
+        INSERT INTO pedidos
+          (usuario_id, valor_total, status, forma_entrega, metodo_pagamento, data_criacao)
+        VALUES
+          (@usuarioId, @valorTotal, 'confirmado', @formaEntrega, @metodoPagamento, @dataCriacao)
+      `)
+      .run({ usuarioId, valorTotal, formaEntrega, metodoPagamento, dataCriacao });
+
+    const pedidoId = info.lastInsertRowid;
+
+    const inserirItem = db.prepare(`
+      INSERT INTO pedido_itens (pedido_id, produto_id, nome, quantidade, preco_unitario)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    for (const item of itens) {
+      inserirItem.run(pedidoId, item.produtoId, item.nome, item.quantidade, item.precoUnitario);
+    }
+
+    db.prepare('DELETE FROM carrinho WHERE usuario_id = ?').run(usuarioId);
+
+    return pedidoId;
+  });
+
+  const pedidoId = registrarPedido();
+
+  return res.status(201).json({
+    pedidoId,
     itens,
     enderecoEntrega,
     formaEntrega,
     metodoPagamento,
-    valorTotal: Number(valorTotal.toFixed(2)),
+    valorTotal,
     status: 'confirmado',
-    dataCriacao: new Date().toISOString(),
-  };
-
-  pedidos.push(novoPedido);
-  carrinhoPrincipal.length = 0;
-
-  const { usuarioId, ...resposta } = novoPedido;
-  return res.status(201).json(resposta);
+    dataCriacao,
+  });
 };


### PR DESCRIPTION
## Issue
Closes #71 - [SQLite] Migrar eControllers (carrinho + pedidos) para SQLite

## Por que este PR existe (re-entrega)
O PR #84 foi mergeado como stacked sobre a branch do #66, mas o merge do #84 caiu na branch base (`feat/sqlite-conexao-db`) **18s depois** do #66 ir pra main - antes do GitHub re-apontar a base pra `main`. Resultado: o commit da migracao **nao chegou na main** (o `eControllers.js` da main ainda usava arrays). Este PR leva exatamente o mesmo commit (cherry-pick de `2f66484`) **direto pra main**.

## Conteudo (identico ao #84, ja validado)
- `import db from '../db/conexao.js'` (saem data/e.js, data/h.js, data/produtos.js)
- **adicionarItemCarrinho (US-04):** SELECT/INSERT/UPDATE na tabela `carrinho`, escopado por `usuario_id`
- **confirmarPedido (US-16):** SELECT do carrinho com JOIN em `produtos`, INSERT em `pedidos` + `pedido_itens` e limpeza do carrinho numa **transacao**
- Prepared statements (anti SQL injection); mesmo contrato HTTP

## Validado rodando o servidor (HTTP real)
- Servidor sobe sem quebrar com o controller migrado + conexao.js
- `POST /auth/login` -> token | `POST /pedidos` -> **201** (itens com nome+preco via JOIN, valorTotal 259.70, carrinho esvaziado)
- Persistencia confirmada nas tabelas `pedidos` e `pedido_itens`
- Repetir -> **400** (carrinho vazio) | sem token -> **401**

## Diff
Apenas `src/controllers/eControllers.js` (a main ja tem o `conexao.js` do #66 mergeado).

## Nota
A US-04 (`adicionarItemCarrinho`) segue sendo codigo morto por colisao de rota com `h.js` - intencional, fora do escopo desta migracao.