### PR TITLE
fix(swagger): declara security: bearerAuth nos endpoints protegidos faltando [#100]

### DIFF
--- a/src/routes/e.js
+++ b/src/routes/e.js
@@ -25,6 +25,8 @@
  *                 type: integer
  *                 description: Quantidade a ser adicionada (deve ser > 0).
  *                 example: 2
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       201:
  *         description: Produto adicionado ao carrinho como novo item.

--- a/src/routes/g.js
+++ b/src/routes/g.js
@@ -15,6 +15,8 @@
  *           type: integer
  *         description: Identificador único do pedido confirmado.
  *         example: 1
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       200:
  *         description: Lista de até 4 produtos recomendados (excluindo os já presentes no pedido).
@@ -54,6 +56,8 @@
  *           type: integer
  *         description: Identificador único do produto.
  *         example: 1
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       200:
  *         description: Produto encontrado com sucesso.

--- a/src/routes/produtos.js
+++ b/src/routes/produtos.js
@@ -132,6 +132,8 @@ router.get('/', listarProdutos);
  *         schema:
  *           type: integer
  *         description: ID do produto
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       200:
  *         description: Produto encontrado


### PR DESCRIPTION
## Issue
Closes #100

## Problema
Endpoints protegidos pelo middleware `autenticarJWT` no `app.js` **nao declaravam `security: [{ bearerAuth: [] }]`** no JSDoc `@openapi`. Efeito pratico: ao clicar em **Authorize** no Swagger UI e colar o token, o **Try it out** desses endpoints NAO enviava o header `Authorization` - voltavam 401 mesmo com o usuario "autenticado". O professor sinalizou que "faltava um pedaco de registrar/autenticar no inicio do Swagger".

## Endpoints corrigidos (3)
- `POST /carrinho/itens` em `src/routes/e.js`
- `GET /produtos/recomendacoes` em `src/routes/g.js`
- `GET /produtos/{id}` em `src/routes/produtos.js` (descoberto na auditoria - estava sem)

## Validacao em runtime
Subi o servidor e auditei `/api-docs.json`:
- **17 endpoints COM security** (todas as protegidas - incluindo as 3 corrigidas)
- **3 endpoints SEM security** (todas legitimamente publicas):
  - `POST /auth/login` (e o proprio login)
  - `GET /enderecos/cep/{cep}` (publico)
  - `GET /produtos` (publico por RNF-02)

## Diff
+8 linhas / -0 em 3 arquivos. So adicionei o bloco `security:` antes de `responses:` em cada JSDoc.

## Fora de escopo
- Estilo alternativo (declarar security global em `app.js`) - se o grupo preferir, vira nova issue
- Colisao `/produtos/{id}` entre produtos.js (vivo) e g.js (sombreado): mesmo padrao do carrinho, intencional, fora deste fix