### PR TITLE
fix(produtos): corrige GET /:id e /recomendacoes (500) + snake -> camel [#108]

### DIFF
--- a/src/controllers/gControllers.js
+++ b/src/controllers/gControllers.js
@@ -1,5 +1,6 @@
 // src/controllers/gControllers.js
 import db from '../db/conexao.js';
+import { toCamelProduto } from './produtosController.js';
 
 // Buscar produto por ID [US-02]
 export const buscarProdutoPorId = (req, res) => {
@@ -15,7 +16,7 @@ export const buscarProdutoPorId = (req, res) => {
     return res.status(404).json({ erro: `Produto com id ${id} não encontrado.` });
   }
 
-  return res.status(200).json(produto);
+  return res.status(200).json(toCamelProduto(produto));
 };
 
 // Buscar produtos recomendados após confirmação do pedido [US-19]
@@ -38,7 +39,7 @@ export const buscarRecomendacoes = (req, res) => {
     LIMIT 4
   `).all(pedidoId);
 
-  return res.status(200).json(recomendacoes);
+  return res.status(200).json(recomendacoes.map(toCamelProduto));
 };
 
 // Atualizar quantidade de item no carrinho [RF-05]

--- a/src/controllers/produtosController.js
+++ b/src/controllers/produtosController.js
@@ -1,6 +1,28 @@
 // src/controllers/produtosController.js
 import db from '../db/conexao.js';
+
 const CATEGORIAS_VALIDAS = ['lampadas', 'luminarias', 'fitas', 'acessorios', 'assistentes'];
+
+// Normaliza a linha do SQLite (snake_case + INTEGER 0/1) para o shape
+// camelCase + boolean esperado pelo frontend (criarCardProduto, PRODUTO, etc).
+// Exportado pra reuso em outros controllers que devolvem produtos (gControllers).
+export const toCamelProduto = (p) => {
+  if (!p) return p;
+  return {
+    id: p.id,
+    nome: p.nome,
+    categoria: p.categoria,
+    descricao: p.descricao,
+    preco: p.preco,
+    desconto: p.desconto,
+    imagem: p.imagem,
+    imagemDetalhes: p.imagem_detalhes,
+    avaliacao: p.avaliacao,
+    totalAvaliacoes: p.total_avaliacoes,
+    destaque: p.destaque === 1,
+    maisVendido: p.mais_vendido === 1,
+  };
+};
 
 // Listar produtos com filtros opcionais [US-01 + RF-03]
 // Queries suportadas: ?categoria, ?destaque=true, ?maisVendido=true
@@ -20,7 +42,7 @@ export const listarProdutos = (req, res) => {
     query += ` AND categoria = ?`;
     params.push(categoria);
   }
-  
+
   if (destaque === 'true') {
     query += ` AND destaque = 1`;
   }
@@ -34,24 +56,5 @@ export const listarProdutos = (req, res) => {
   }
 
   const resultado = db.prepare(query).all(...params);
-
-  // Converte 0/1 do SQLite para boolean
-  const produtos = resultado.map((p) => ({
-    ...p,
-    destaque:    p.destaque    === 1,
-    maisVendido: p.mais_vendido === 1,
-  }));
-
-  return res.status(200).json(produtos);
+  return res.status(200).json(resultado.map(toCamelProduto));
 };
-
-export function getProdutoPorId(req, res) {
-  const id = parseInt(req.params.id);
-  const produto = produtos.find(p => p.id === id);
-
-  if (!produto) {
-    return res.status(404).json({ mensagem: 'Produto não encontrado.' });
-  }
-
-  return res.status(200).json(produto);
-}

--- a/src/routes/produtos.js
+++ b/src/routes/produtos.js
@@ -63,7 +63,7 @@
  *           example: Categoria "invalida" não encontrada.
  */
 import { Router } from 'express';
-import { listarProdutos, getProdutoPorId } from '../controllers/produtosController.js';
+import { listarProdutos } from '../controllers/produtosController.js';
 const router = Router();
 
 /**
@@ -118,32 +118,8 @@ const router = Router();
  */
 router.get('/', listarProdutos);
 
-/**
- * @openapi
- * /produtos/{id}:
- *   get:
- *     summary: Retorna um produto pelo ID
- *     tags:
- *       - Produtos
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: integer
- *         description: ID do produto
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Produto encontrado
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Produto'
- *       404:
- *         description: Produto não encontrado
- */
-router.get('/:id', getProdutoPorId);
+// GET /produtos/:id e' servido por routes/g.js (gControllers.buscarProdutoPorId),
+// que ja usa SQL e mapeia snake -> camel. Mantinha-se aqui uma versao duplicada e bugada
+// (referenciando variavel `produtos` que nao existia) - removida em #108.
 
 export default router;


### PR DESCRIPTION
## Issue
Closes #108

## 2 bugs criticos + 1 descontinuidade resolvidos

### CRITICOS (eram 500)
- `GET /produtos/:id` -> `produtos is not defined` em `produtosController.getProdutoPorId`. **Tela PRODUTO inteira quebrava** (o redirect-on-fail do produto.js mandava o user pra HOME).
- `GET /produtos/recomendacoes` -> mesmo erro. **Secao 'Voce tambem pode gostar' da CONFIRMACAO** quebrava.

### MEDIO (renderizava 'undefined')
- snake_case (`total_avaliacoes`, `imagem_detalhes`, `mais_vendido`) vazava no JSON. Front faz `produto.totalAvaliacoes` -> `undefined` -> "(undefined avaliacoes)" nos cards.

## Solucao

1. **Removido** `getProdutoPorId` bugado de `produtosController.js` (+ import + rota em `routes/produtos.js`). A versao correta em `gControllers.buscarProdutoPorId` (que ja usa SQL) passa a responder o GET /:id - antes estava sombreada pela ordem dos mounts.
2. **Bonus:** removendo o `/:id` bugado, `/recomendacoes` deixa de ser engolido (`parseInt('recomendacoes') = NaN -> bug`) e chega no gRouter que tem `/recomendacoes` especifico.
3. **Helper `toCamelProduto(p)`** criado em `produtosController.js` (exportado), aplicado em `listarProdutos`, `buscarProdutoPorId`, `buscarRecomendacoes`. Normaliza snake -> camel + INTEGER 0/1 -> boolean.

## Diff
+34/-44 em 3 arquivos.

## Validacao runtime (com seed populado: 40 produtos)
```
GET /produtos             -> 40 itens, todos camelCase, snake removido
                             totalAvaliacoes:128, imagemDetalhes:'...', maisVendido:true
GET /produtos/1           -> 200 com shape correto (era 500)
GET /produtos/recomendacoes?pedidoId=N -> 4 itens camelCase (era 500)
```

## Fora de escopo
- `GET /carrinho` sem `imagem`/`precoUnitario`/`precoTotal` -> issue propria quando Henrique fizer #95
- Envelope de `GET /favoritos` (`{favoritos: [...]}`) -> decisao do grupo (front-side fix)
- Convencao geral de envelope nos endpoints -> refactor maior, fora do escopo deste fix