### PR TITLE
fix(bulbe): adiciona constante tiposEntrega faltando em selecionarEnt…

### DIFF
--- a/src/controllers/bulbeControllers.js
+++ b/src/controllers/bulbeControllers.js
@@ -1,4 +1,10 @@
 import db from '../db/conexao.js';
+
+const tiposEntrega = {
+    padrao:  { prazoEstimado: '6-9 dias', custoEntrega: 10 },
+    express: { prazoEstimado: '3-5 dias', custoEntrega: 25 },
+};
+
 //Remover item dos favoritos [US-11]
 export const removerFavoritos = (req,res)=>{
     const id = parseInt(req.params.id,10);


### PR DESCRIPTION
…rega

A variavel tiposEntrega era importada de src/data/bulbe.js, removido em #110. Declarada inline no proprio controller - nao justifica arquivo separado. Corrige POST /api/v1/bulbe/entrega retornando 500 em qualquer chamada.