### PR TITLE
fix(back): inclui frete no valorTotal + imagem no GET /carrinho [#120]

### DIFF
--- a/src/controllers/eControllers.js
+++ b/src/controllers/eControllers.js
@@ -1,6 +1,13 @@
 // src/controllers/eControllers.js
 import db from '../db/conexao.js';
 
+// Custos de entrega (mesmas opcoes definidas em bulbeControllers.tiposEntrega).
+// Duplicacao intencional - constante pequena, sem arquivo de config novo. Manter em sincronia.
+const TIPOS_ENTREGA = {
+  padrao:  { custoEntrega: 10 },
+  express: { custoEntrega: 25 },
+};
+
 // Adicionar produto ao carrinho [US-04]
 export const adicionarItemCarrinho = (req, res) => {
   const { produtoId, quantidade } = req.body;
@@ -73,11 +80,12 @@ export const confirmarPedido = (req, res) => {
     });
   }
 
-  const valorTotal = Number(
-    itens
-      .reduce((total, item) => total + item.precoUnitario * item.quantidade, 0)
-      .toFixed(2),
+  const valorItens = itens.reduce(
+    (total, item) => total + item.precoUnitario * item.quantidade,
+    0,
   );
+  const custoFrete = TIPOS_ENTREGA[formaEntrega]?.custoEntrega ?? 0;
+  const valorTotal = Number((valorItens + custoFrete).toFixed(2));
 
   const dataCriacao = new Date().toISOString();
 

--- a/src/controllers/hControllers.js
+++ b/src/controllers/hControllers.js
@@ -6,6 +6,7 @@ const getCarrinhoFormatado = (usuarioId) =>
     SELECT c.produto_id AS produtoId,
            p.nome        AS nome,
            p.preco       AS preco,
+           p.imagem      AS imagem,
            c.quantidade  AS quantidade
     FROM carrinho c
     JOIN produtos p ON p.id = c.produto_id


### PR DESCRIPTION
## Issue
Closes #120

## 2 bugs criticos da apresentacao, 1 PR, +13/-4 em 2 arquivos

### B1) Frete sumido no valorTotal (eControllers.confirmarPedido)
Antes: carrinho R$ 35 + entrega express -> pedido com `valorTotal: 35` (frete some)
Agora: carrinho R$ 35 + entrega express -> pedido com `valorTotal: 60`

Implementacao: constante `TIPOS_ENTREGA` (duplicada conscientemente de bulbeControllers - 4 linhas vs criar arquivo de config; escolha de escopo minimo). Soma `custoFrete` ao reduce de itens antes do INSERT. Fallback graceful: forma desconhecida -> custoFrete = 0.

### B2) imagem ausente em GET /carrinho (hControllers.getCarrinhoFormatado)
Antes: `{produtoId, nome, preco, quantidade}` - sem imagem, front mostrava placeholder generico
Agora: `{imagem, nome, preco, produtoId, quantidade}` - imagem real

1 linha: adicionado `p.imagem AS imagem` ao JOIN. Como o helper eh usado por listar/adicionar/remover/limpar carrinho, **todos** os endpoints de carrinho passam a devolver imagem.

## Validacao runtime (backend fresh em /tmp + curl)
```
GET /carrinho                                   -> keys incluem 'imagem' ✅
POST /pedidos formaEntrega:padrao (itens R$70)  -> valorTotal R$ 80.00 ✅
POST /pedidos formaEntrega:express (itens R$35) -> valorTotal R$ 60.00 ✅
POST /pedidos formaEntrega:sedex (desconhecida) -> valorTotal R$ 35.00 ✅ (graceful)
```

## Front nao precisa de mudanca
- CARRINHO/carrinho.js linha 59 ja le `item.imagem || placeholder` -> imagem real aparece automatico
- CONFIRMACAO/TCC.js le `pedido.valorTotal` -> mostra o total correto com frete ja incluido

## Decisao registrada
`TIPOS_ENTREGA` duplicado em `eControllers` e `bulbeControllers`. Aceito porque:
- Constante pequena (2 entradas)
- Criar arquivo de config nao caberia no escopo minimo do fix
- Comentario adicionado em ambos os arquivos avisando da sincronia necessaria

Se um dia adicionar 'sedex', 'motoboy', etc., padronizar via `src/config/entregas.js` vira refactor proprio.